### PR TITLE
fix(resolvers): move resolvers `tini` argument to entrypoint

### DIFF
--- a/.konflux/dockerfiles/resolvers.Dockerfile
+++ b/.konflux/dockerfiles/resolvers.Dockerfile
@@ -50,6 +50,5 @@ RUN groupadd -r -g 65532 nonroot && \
     useradd --no-log-init -r -u 65532 -g nonroot nonroot
 USER 65532
 
-ENTRYPOINT ["/ko-app/tini", "--"]
-CMD ["/ko-app/resolvers"]
+ENTRYPOINT ["/ko-app/tini", "--", "/ko-app/resolvers"]
 


### PR DESCRIPTION
If the TektonConfig has pipelines performance settings such as `threads-per-controller`, those settings' values are set as the `args` field on the container, overriding the image's configured `CMD` array. In order to ensure the `resolver` binary is included in the arguments to tini and not overwritten by the operator it must be in the entrypoint.

Part of https://issues.redhat.com/browse/SRVKP-7755