### PR TITLE
 fix(SRVKP-8564): Update nightly tini entrypoint to align with upstream 

### DIFF
--- a/.konflux/dockerfiles/resolvers.Dockerfile
+++ b/.konflux/dockerfiles/resolvers.Dockerfile
@@ -31,7 +31,8 @@ ENV RESOLVERS=/usr/local/bin/resolvers \
 COPY --from=builder /tmp/resolvers /ko-app/resolvers
 COPY head ${KO_DATA_PATH}/HEAD
 
-COPY --from=dependency-builder /dependencies/tini/tini /ko-app/tini
+COPY --from=dependency-builder /dependencies/tini/tini /sbin/tini
+RUN chmod 0755 /sbin/tini && chown root:root /sbin/tini
 
 LABEL \
       com.redhat.component="openshift-pipelines-resolvers-rhel9-container" \
@@ -50,5 +51,5 @@ RUN groupadd -r -g 65532 nonroot && \
     useradd --no-log-init -r -u 65532 -g nonroot nonroot
 USER 65532
 
-ENTRYPOINT ["/ko-app/tini", "--", "/ko-app/resolvers"]
+ENTRYPOINT ["/sbin/tini", "--", "/ko-app/resolvers"]
 


### PR DESCRIPTION
When upstream started using tini for the entrypoint the path was configured in the deployment yaml to be /sbin/tini. This change is required to ensure the tini binary exists at that path since it overrides the entrypoint configured in the dockerfile

Mirrors #1103 for nightly build