### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-pipeline-1-19-workingdirinit

### DIFF
--- a/.konflux/dockerfiles/workingdirinit.Dockerfile
+++ b/.konflux/dockerfiles/workingdirinit.Dockerfile
@@ -25,6 +25,7 @@ COPY head ${KO_DATA_PATH}/HEAD
 
 LABEL \
       com.redhat.component="openshift-pipelines-workingdirinit-rhel9-container" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.19::el9" \
       name="openshift-pipelines/pipelines-workingdirinit-rhel9" \
       version=$VERSION \
       summary="Red Hat OpenShift Pipelines Workingdirinit" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
