### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-pipeline-1-19-resolvers

### DIFF
--- a/.konflux/dockerfiles/resolvers.Dockerfile
+++ b/.konflux/dockerfiles/resolvers.Dockerfile
@@ -42,7 +42,8 @@ LABEL \
       description="Red Hat OpenShift Pipelines Resolvers" \
       io.k8s.display-name="Red Hat OpenShift Pipelines Resolvers" \
       io.k8s.description="Red Hat OpenShift Pipelines Resolvers" \
-      io.openshift.tags="pipelines,tekton,openshift"
+      io.openshift.tags="pipelines,tekton,openshift" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.19::el9"
 
 RUN microdnf update && microdnf install -y git && microdnf clean all
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
