### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-pipeline-1-18-workingdirinit

### DIFF
--- a/.konflux/dockerfiles/workingdirinit.Dockerfile
+++ b/.konflux/dockerfiles/workingdirinit.Dockerfile
@@ -27,6 +27,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-workingdirinit-rhel9-container" \
       name="openshift-pipelines/pipelines-workingdirinit-rhel9" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.18::el9" \
       summary="Red Hat OpenShift Pipelines Workingdirinit" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Workingdirinit" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
