### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-pipeline-1-18-nop

### DIFF
--- a/.konflux/dockerfiles/nop.Dockerfile
+++ b/.konflux/dockerfiles/nop.Dockerfile
@@ -41,7 +41,8 @@ LABEL \
       vendor="Red Hat, Inc." \
       distribution-scope="public" \
       url="https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9-minimal/images/9.4-1227.1725849298" \
-      release="1227.1725849298"
+      release="1227.1725849298" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.18::el9"
 
 USER 65532
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
