### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-pipeline-1-16-webhook

### DIFF
--- a/.konflux/dockerfiles/webhook.Dockerfile
+++ b/.konflux/dockerfiles/webhook.Dockerfile
@@ -26,6 +26,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-webhook-rhel8-container" \
       name="openshift-pipelines/pipelines-webhook-rhel8" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.16::el8" \
       summary="Red Hat OpenShift Pipelines Webhook" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Webhook" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
